### PR TITLE
Refactor some codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,11 +30,13 @@ dependencies = [
  "configparser",
  "dirs 3.0.1",
  "image",
+ "log",
  "notify-rust",
  "regex",
  "ring",
  "rustls",
  "rustls-pemfile",
+ "simple_logger",
  "structopt",
  "webpki",
  "x509-signature",
@@ -214,6 +216,17 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1081,6 +1094,19 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.9",
  "syn 1.0.60",
+]
+
+[[package]]
+name = "simple_logger"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
+dependencies = [
+ "atty",
+ "chrono",
+ "colored",
+ "log",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,8 +227,7 @@ dependencies = [
 [[package]]
 name = "configparser"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2616d8c1fbf887d76dd8e067ec1bc3be7669994378428b4415a8e4ad57baae1"
+source = "git+https://github.com/mexili/configparser-rs?rev=af5b3db4d080fcbc709f2597a22fefb2218dce64#af5b3db4d080fcbc709f2597a22fefb2218dce64"
 
 [[package]]
 name = "constant_time_eq"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 [[package]]
 name = "notify-rust"
 version = "4.2.2"
-source = "git+https://github.com/skystar-p/notify-rust?branch=image_rgba#36986409e52f3dd7a8f9d21ff6be6eb8edd76d7e"
+source = "git+https://github.com/pbzweihander/notify-rust?branch=image-with-alpha#44f5b3d5905e8dc274f216e86fc9c3f4b8fb92dd"
 dependencies = [
  "image",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,9 @@ structopt = "0.3.21"
 webpki = "0.21.4"
 x509-signature = "0.5.0"
 
+# FIXME: Use original when merged and released
 [dependencies.notify-rust]
-git = "https://github.com/skystar-p/notify-rust"
-branch = "image_rgba"
+git = "https://github.com/pbzweihander/notify-rust"
+branch = "image-with-alpha"
 features = ["z", "images"]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,16 @@
 [package]
 name = "an2linuxserver"
 version = "0.1.0"
-authors = ["rusty <rusty@spoqa.com>"]
+description = "Sync Android notifications to a Linux (and more!) desktop, inspired by https://github.com/rootkiwi/an2linuxserver"
+authors = [
+    "Kangwook Lee <pbzweihander@gmail.com>",
+    "Jae Hyeon Park <skystar@skystar.dev>",
+]
 edition = "2018"
+homepage = "https://github.com/pbzweihander/an2linuxserver-rs"
+repository = "https://github.com/pbzweihander/an2linuxserver-rs"
+readme = "README.md"
+license = "GPL-3.0-or-later"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ license = "GPL-3.0-or-later"
 [dependencies]
 anyhow = "1.0.38"
 base64 = "0.13.0"
-configparser = "2.0.0"
+# configparser = "2.0.0"
+# FIXME: Remove when released
+configparser = { git = "https://github.com/mexili/configparser-rs", rev = "af5b3db4d080fcbc709f2597a22fefb2218dce64" }
 dirs = "3.0.1"
 image = "0.23.13"
 regex = "1.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Sync Android notifications to a Linux (and more!) desktop, inspired by https://github.com/rootkiwi/an2linuxserver"
 authors = [
     "Kangwook Lee <pbzweihander@gmail.com>",
-    "Jae Hyeon Park <skystar@skystar.dev>",
+    "Jaehyeon Park <skystar@skystar.dev>",
 ]
 edition = "2018"
 homepage = "https://github.com/pbzweihander/an2linuxserver-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,12 @@ base64 = "0.13.0"
 configparser = { git = "https://github.com/mexili/configparser-rs", rev = "af5b3db4d080fcbc709f2597a22fefb2218dce64" }
 dirs = "3.0.1"
 image = "0.23.13"
+log = "0.4.14"
 regex = "1.4.3"
 ring = "0.16.20"
 rustls-pemfile = "0.2.0"
 rustls = { version = "0.19.0", features = ["dangerous_configuration"] }
+simple_logger = "1.11.0"
 structopt = "0.3.21"
 webpki = "0.21.4"
 x509-signature = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # an2linuxserver-rs
+
 Rust implementation of https://github.com/rootkiwi/an2linuxserver
+
+## License
+
+_an2linuxserver-rs_ is distributed under the terms of [GNU General Public License 3](https://www.gnu.org/licenses/gpl-3.0.html).
+
+_an2linuxserver-rs_ is re-implementation of [rootkiwi/an2linuxserver](https://github.com/rootkiwi/an2linuxserver).
+
+See [LICENSE] for more details.

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,7 +239,7 @@ pub struct AuthorizedCertsManager {
 
 impl AuthorizedCertsManager {
     /// returns (Fingerprint, Certificate) map
-    pub fn parse_authorized_certs(&self) -> Result<HashMap<String, rustls::Certificate>> {
+    pub fn load(&self) -> Result<HashMap<String, rustls::Certificate>> {
         if !self.path.is_file() {
             fs::File::create(&self.path)?;
             return Ok(HashMap::new());
@@ -276,7 +276,7 @@ impl AuthorizedCertsManager {
         Ok(certs)
     }
 
-    pub fn add_authorized_cert(&self, cert_der: &[u8]) -> Result<()> {
+    pub fn add(&self, cert_der: &[u8]) -> Result<()> {
         let digest = ring::digest::digest(&ring::digest::SHA256, cert_der);
         let digest_hex_formatted = digest
             .as_ref()
@@ -284,7 +284,7 @@ impl AuthorizedCertsManager {
             .map(|x| format!("{:02X}", x))
             .collect::<Vec<String>>()
             .join(":");
-        let authorized_certs = self.parse_authorized_certs()?;
+        let authorized_certs = self.load()?;
         if authorized_certs.contains_key(&digest_hex_formatted) {
             return Ok(());
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,32 +152,13 @@ impl NotificationConfig {
 #[derive(Debug, Clone)]
 pub struct ConfigManager {
     config_dir: PathBuf,
-    config: Option<Config>,
 }
 
 impl ConfigManager {
-    pub fn try_default(load_config: bool) -> Result<Self> {
-        let config_home_dir =
-            dirs::config_dir().ok_or_else(|| format_err!("Unsupported platform"))?;
+    pub fn new() -> Self {
+        let config_home_dir = dirs::config_dir().expect("Unsupported platform");
         let config_dir = config_home_dir.join("an2linux_rs");
-        let mut config_manager = Self {
-            config_dir,
-            config: None,
-        };
-        config_manager.ensure_config_dir_exists()?;
-        config_manager.ensure_certificate_and_rsa_private_key_exists()?;
-
-        if load_config {
-            let config_file_path = config_manager.config_file_path();
-            if !config_file_path.is_file() {
-                Config::create_default_config_to_path(&config_file_path)?;
-            }
-            let config_content = fs::read_to_string(&config_file_path)?;
-            let mut ini = Ini::new_cs();
-            ini.read(config_content).map_err(Error::msg)?;
-            config_manager.config = Some(Config::from_ini(&ini)?);
-        }
-        Ok(config_manager)
+        Self { config_dir }
     }
 
     pub fn config_file_path(&self) -> PathBuf {
@@ -227,28 +208,75 @@ impl ConfigManager {
         Ok(())
     }
 
-    pub fn get_config(&self) -> Option<&Config> {
-        if let Some(config) = &self.config {
-            Some(&config)
-        } else {
-            None
+    pub fn get_or_create_config(&self) -> Result<Config> {
+        let config_file_path = self.config_file_path();
+        if !config_file_path.is_file() {
+            Config::create_default_config_to_path(&config_file_path)?;
         }
+        let config_content = fs::read_to_string(&config_file_path)?;
+        let mut ini = Ini::new_cs();
+        ini.read(config_content).map_err(Error::msg)?;
+        Ok(Config::from_ini(&ini)?)
     }
 
-    pub fn parse_authorized_cert(&self) -> Result<AuthorizedCerts> {
-        let authorized_certs_path = self.authorized_certs_path();
-        if !authorized_certs_path.is_file() {
-            fs::File::create(authorized_certs_path)?;
-            return Ok(AuthorizedCerts::new());
+    pub fn authorized_certs_manager(&self) -> AuthorizedCertsManager {
+        AuthorizedCertsManager {
+            path: self.authorized_certs_path(),
         }
-        let mut f = fs::File::open(authorized_certs_path)?;
-        let mut buf = String::new();
-        f.read_to_string(&mut buf)?;
-        AuthorizedCerts::from_str(&buf)
+    }
+}
+
+impl Default for ConfigManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Struct to add or parse authorized certs
+pub struct AuthorizedCertsManager {
+    path: PathBuf,
+}
+
+impl AuthorizedCertsManager {
+    /// returns (Fingerprint, Certificate) map
+    pub fn parse_authorized_certs(&self) -> Result<HashMap<String, rustls::Certificate>> {
+        if !self.path.is_file() {
+            fs::File::create(&self.path)?;
+            return Ok(HashMap::new());
+        }
+        let mut f = fs::File::open(&self.path)?;
+        let mut content = String::new();
+        f.read_to_string(&mut content)?;
+        let certs = content
+            .lines()
+            .filter_map(|line| {
+                let s = line.split_whitespace().collect::<Vec<&str>>();
+                if s.len() != 2 {
+                    return None;
+                }
+                let fingerprint = {
+                    let splitted = s[0].splitn(2, ':').collect::<Vec<&str>>();
+                    if splitted.len() < 2 {
+                        ""
+                    } else {
+                        splitted[0]
+                    }
+                };
+                if fingerprint.is_empty() {
+                    return None;
+                }
+                let cert_der = base64::decode(s[1]).unwrap_or_default();
+                if cert_der.is_empty() {
+                    None
+                } else {
+                    Some((fingerprint.to_string(), rustls::Certificate(cert_der)))
+                }
+            })
+            .collect();
+        Ok(certs)
     }
 
-    pub fn add_authorized_cert(&self, cert_der: &dyn AsRef<[u8]>) -> Result<()> {
-        let cert_der = cert_der.as_ref();
+    pub fn add_authorized_cert(&self, cert_der: &[u8]) -> Result<()> {
         let digest = ring::digest::digest(&ring::digest::SHA256, cert_der);
         let digest_hex_formatted = digest
             .as_ref()
@@ -256,9 +284,9 @@ impl ConfigManager {
             .map(|x| format!("{:02X}", x))
             .collect::<Vec<String>>()
             .join(":");
-        let authorized_certs = self.parse_authorized_cert()?;
-        if authorized_certs.certs.get(&digest_hex_formatted).is_some() {
-            bail!("client certificate already exists")
+        let authorized_certs = self.parse_authorized_certs()?;
+        if authorized_certs.contains_key(&digest_hex_formatted) {
+            return Ok(());
         }
 
         let digest_hex_formatted = format!("SHA256:{}", digest_hex_formatted);
@@ -266,58 +294,9 @@ impl ConfigManager {
         let mut f = fs::OpenOptions::new()
             .write(true)
             .append(true)
-            .open(self.authorized_certs_path())?;
+            .open(&self.path)?;
         let s = format!("{} {}\n", digest_hex_formatted, base64_str);
         f.write_all(&s.into_bytes())?;
         Ok(())
-    }
-}
-
-// data structure that holds `authorized_certs` file content
-pub struct AuthorizedCerts {
-    // Fingerprint -> Certificate map
-    certs: HashMap<String, Vec<u8>>,
-}
-
-impl AuthorizedCerts {
-    fn new() -> Self {
-        Self {
-            certs: HashMap::new(),
-        }
-    }
-
-    fn from_str(content: &dyn AsRef<str>) -> Result<Self> {
-        let content = content.as_ref();
-        let mut hashmap: HashMap<String, Vec<u8>> = HashMap::new();
-        for line in content.lines() {
-            let s = line.split_whitespace().collect::<Vec<&str>>();
-            if s.len() != 2 {
-                continue;
-            }
-            let fingerprint = {
-                let splitted = s[0].splitn(2, ':').collect::<Vec<&str>>();
-                if splitted.len() < 2 {
-                    ""
-                } else {
-                    splitted[0]
-                }
-            };
-            if fingerprint.is_empty() {
-                continue;
-            }
-            let cert_der = base64::decode(s[1]).unwrap_or_default();
-            if cert_der.is_empty() {
-                continue;
-            }
-            hashmap.insert(fingerprint.to_owned(), cert_der);
-        }
-        Ok(Self { certs: hashmap })
-    }
-
-    pub fn get_all_der_certs(&self) -> Vec<rustls::Certificate> {
-        self.certs
-            .values()
-            .map(|cert| rustls::Certificate(cert.clone()))
-            .collect()
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,11 @@
-use anyhow::{bail, format_err, Error, Result};
-use configparser::ini::Ini;
-use regex::Regex;
 use std::collections::HashMap;
 use std::fs;
 use std::io::*;
 use std::path::{Path, PathBuf};
+
+use anyhow::{bail, format_err, Error, Result};
+use configparser::ini::Ini;
+use regex::Regex;
 
 const DEFAULT_CONFIG_FILE_CONTENT: &str = include_str!("default_config.ini");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ fn main() -> Result<()> {
         // TODO: show warning
     }
 
-    // TODO: Implement core
     // TODO: signal handling
     let tls_info = tls::TlsInfoBuilder::new(certs, privkey);
     if config.tcp.enabled {
@@ -51,6 +50,8 @@ fn main() -> Result<()> {
             }
         }
     }
+
+    // TODO: Implement bluetooth
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Result};
-use structopt::StructOpt;
 
 mod config;
 mod opt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,9 +44,7 @@ fn main() -> Result<()> {
             }
             None => {
                 // notification daemon mode
-                let authorized_certs = config_manager
-                    .authorized_certs_manager()
-                    .parse_authorized_certs()?;
+                let authorized_certs = config_manager.authorized_certs_manager().load()?;
                 let tls_config = tls_info
                     .with_client_auth(utils::hashmap_into_values(authorized_certs))
                     .build()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn main() -> Result<()> {
                 // pairing request
                 let authorized_certs_manager = config_manager.authorized_certs_manager();
                 let tls_config = tls_info.build_tls_info()?;
-                tcp::pairing_tcp_handler(&config, &authorized_certs_manager, tls_config)?;
+                tcp::pairing_tcp_handler(&config.tcp, &authorized_certs_manager, tls_config)?;
             }
             None => {
                 // notification daemon mode
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
                 let tls_config = tls_info
                     .with_client_auth(utils::hashmap_into_values(authorized_certs))
                     .build_tls_info()?;
-                tcp::notification_tcp_handler(&config, tls_config)?;
+                tcp::notification_tcp_handler(&config.tcp, tls_config)?;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,10 @@ mod tls;
 mod utils;
 
 fn main() -> Result<()> {
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Info)
+        .init()?;
+
     // parse command-line arguments
     let opt = opt::Opt::from_args();
     let config_manager = config::ConfigManager::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<()> {
             Some(opt::Subcommand::Pair) => {
                 // pairing request
                 let authorized_certs_manager = config_manager.authorized_certs_manager();
-                let tls_config = tls_info.build_tls_info()?;
+                let tls_config = tls_info.build()?;
                 tcp::pairing_tcp_handler(&config.tcp, &authorized_certs_manager, tls_config)?;
             }
             None => {
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
                     .parse_authorized_certs()?;
                 let tls_config = tls_info
                     .with_client_auth(utils::hashmap_into_values(authorized_certs))
-                    .build_tls_info()?;
+                    .build()?;
                 tcp::notification_tcp_handler(&config.tcp, tls_config)?;
             }
         }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -10,3 +10,9 @@ pub struct Opt {
 pub enum Subcommand {
     Pair,
 }
+
+impl Opt {
+    pub fn from_args() -> Self {
+        StructOpt::from_args()
+    }
+}

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -6,16 +6,16 @@ use std::time::Duration;
 use anyhow::{bail, Result};
 use notify_rust::{Image, Notification};
 
-use crate::config::{AuthorizedCertsManager, Config};
+use crate::config::{AuthorizedCertsManager, TcpServerConfig};
 use crate::protocol::{ConnType, NotificationFlag, PairingResponse};
 use crate::tls::TlsInfo;
 
 pub fn pairing_tcp_handler(
-    config: &Config,
+    config: &TcpServerConfig,
     authorized_certs_manager: &AuthorizedCertsManager,
     tls_info: TlsInfo,
 ) -> Result<()> {
-    let port = config.tcp.port;
+    let port = config.port;
     let bind_addr = SocketAddr::from(([0, 0, 0, 0], port as u16));
     let listener = TcpListener::bind(bind_addr)?;
     for stream in listener.incoming() {
@@ -129,8 +129,8 @@ fn handle_pair_request(
     Ok(())
 }
 
-pub fn notification_tcp_handler(config: &Config, tls_info: TlsInfo) -> Result<()> {
-    let port = config.tcp.port;
+pub fn notification_tcp_handler(config: &TcpServerConfig, tls_info: TlsInfo) -> Result<()> {
+    let port = config.port;
     let bind_addr = SocketAddr::from(([0, 0, 0, 0], port as u16));
     let listener = TcpListener::bind(bind_addr)?;
     for stream in listener.incoming() {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -6,9 +6,9 @@ use std::time::Duration;
 use anyhow::{bail, Result};
 use notify_rust::{Image, Notification};
 
-use super::config::ConfigManager;
-use super::protocol::{ConnType, NotificationFlag, PairingResponse};
-use super::tls::TlsInfo;
+use crate::config::ConfigManager;
+use crate::protocol::{ConnType, NotificationFlag, PairingResponse};
+use crate::tls::TlsInfo;
 
 pub fn pairing_tcp_handler(config_manager: &ConfigManager, tls_info: TlsInfo) -> Result<()> {
     let port = config_manager.get_config().unwrap().tcp.port;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,3 +1,4 @@
+use std::convert::TryFrom;
 use std::io::prelude::*;
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::time::Duration;
@@ -237,15 +238,11 @@ fn handle_notification_request(mut stream: TcpStream, tls_info: &TlsInfo) -> Res
     };
 
     // TODO: filter message
-    let image = image::load_from_memory(&icon_bytes)?.into_rgba8();
+
     Notification::new()
         .summary(&title)
         .body(&message)
-        .image_data(Image::from_rgba(
-            image.width() as i32,
-            image.height() as i32,
-            image.into_raw(),
-        )?)
+        .image_data(Image::try_from(image::load_from_memory(&icon_bytes)?)?)
         .show()?;
 
     Ok(())

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -124,7 +124,7 @@ fn handle_pair_request(
     tls_stream.write_all(&[PairingResponse::Accept.into()])?;
 
     // add to authorized_certs
-    authorized_certs_manager.add_authorized_cert(&client_cert)?;
+    authorized_certs_manager.add(&client_cert)?;
 
     Ok(())
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -19,16 +19,14 @@ pub fn pairing_tcp_handler(
     let bind_addr = SocketAddr::from(([0, 0, 0, 0], port as u16));
     let listener = TcpListener::bind(bind_addr)?;
     for stream in listener.incoming() {
-        // FIXME
-        #[allow(clippy::single_match)]
         match stream {
             Ok(stream) => {
                 handle_pairing_connection(stream, authorized_certs_manager, &tls_info)?;
                 println!("successfully paired");
                 return Ok(());
             }
-            Err(_) => {
-                // TODO: log to stderr and continue
+            Err(e) => {
+                eprintln!("error handling incoming stream: {:?}", e);
             }
         }
     }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -136,17 +136,14 @@ pub fn notification_tcp_handler(config: &Config, tls_info: TlsInfo) -> Result<()
     let bind_addr = SocketAddr::from(([0, 0, 0, 0], port as u16));
     let listener = TcpListener::bind(bind_addr)?;
     for stream in listener.incoming() {
-        // FIXME
-        #[allow(clippy::single_match)]
         match stream {
             Ok(stream) => {
                 if let Err(e) = handle_notification_connection(stream, &tls_info) {
-                    // TODO: log to stderr
-                    println!("error on notification handler: {:?}", e);
+                    log::error!("error on notification handler: {:?}", e);
                 }
             }
-            Err(_) => {
-                // TODO: log to stderr and continue
+            Err(e) => {
+                log::error!("error handling incoming stream: {:?}", e);
             }
         }
     }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,15 +1,15 @@
-use anyhow::{bail, Result};
-use rustls::internal::msgs::handshake::DigitallySignedStruct;
-use rustls::SignatureScheme as RScheme;
-use rustls::{
-    ClientCertVerified, ClientCertVerifier, DistinguishedNames, HandshakeSignatureValid, TLSError,
-};
 use std::fs;
 use std::io::BufReader;
 use std::path::Path;
 use std::sync::Arc;
-use x509_signature::parse_certificate;
-use x509_signature::SignatureScheme as XScheme;
+
+use anyhow::{bail, Result};
+use rustls::internal::msgs::handshake::DigitallySignedStruct;
+use rustls::{
+    ClientCertVerified, ClientCertVerifier, DistinguishedNames, HandshakeSignatureValid,
+    SignatureScheme as RScheme, TLSError,
+};
+use x509_signature::{parse_certificate, SignatureScheme as XScheme};
 
 #[derive(Clone)]
 pub struct TlsInfo {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -78,7 +78,7 @@ impl TlsInfoBuilder {
         }
     }
 
-    pub fn build_tls_info(self) -> Result<TlsInfo> {
+    pub fn build(self) -> Result<TlsInfo> {
         let mut config = if let Some(client_certs) = self.client_certs {
             let custom_cert_verifier = Arc::new(CustomClientCertVerifier::new(client_certs)?);
             rustls::ServerConfig::new(custom_cert_verifier)

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -13,8 +13,18 @@ use x509_signature::{parse_certificate, SignatureScheme as XScheme};
 
 #[derive(Clone)]
 pub struct TlsInfo {
-    pub certs: Vec<rustls::Certificate>,
-    pub config: rustls::ServerConfig,
+    certs: Vec<rustls::Certificate>,
+    config: Arc<rustls::ServerConfig>,
+}
+
+impl TlsInfo {
+    pub fn get_first_cert(&self) -> &rustls::Certificate {
+        &self.certs[0]
+    }
+
+    pub fn config(&self) -> Arc<rustls::ServerConfig> {
+        self.config.clone()
+    }
 }
 
 pub fn load_certs(filename: &Path) -> Result<Vec<rustls::Certificate>> {
@@ -69,24 +79,17 @@ impl TlsInfoBuilder {
     }
 
     pub fn build_tls_info(self) -> Result<TlsInfo> {
-        if let Some(client_certs) = self.client_certs {
+        let mut config = if let Some(client_certs) = self.client_certs {
             let custom_cert_verifier = Arc::new(CustomClientCertVerifier::new(client_certs)?);
-            let mut config = rustls::ServerConfig::new(custom_cert_verifier);
-            config.set_single_cert(self.server_certs.clone(), self.privkey)?;
-
-            Ok(TlsInfo {
-                certs: self.server_certs,
-                config,
-            })
+            rustls::ServerConfig::new(custom_cert_verifier)
         } else {
-            let mut config = rustls::ServerConfig::new(rustls::NoClientAuth::new());
-            config.set_single_cert(self.server_certs.clone(), self.privkey)?;
-
-            Ok(TlsInfo {
-                certs: self.server_certs,
-                config,
-            })
-        }
+            rustls::ServerConfig::new(rustls::NoClientAuth::new())
+        };
+        config.set_single_cert(self.server_certs.clone(), self.privkey)?;
+        Ok(TlsInfo {
+            certs: self.server_certs,
+            config: Arc::new(config),
+        })
     }
 }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -90,7 +90,7 @@ impl TlsInfoBuilder {
     }
 }
 
-pub struct CustomClientCertVerifier {
+struct CustomClientCertVerifier {
     allowed_certs: Vec<rustls::Certificate>,
     subject_names: DistinguishedNames,
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,7 @@
+use std::collections::HashMap;
+
+/// Convert HashMap into values vector.
+/// Remove when HashMap::into_values is stabilized (https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#method.into_values)
+pub fn hashmap_into_values<K, V, S>(map: HashMap<K, V, S>) -> Vec<V> {
+    map.into_iter().map(|(_, v)| v).collect()
+}


### PR DESCRIPTION
- authorized certs를 관리하는 타입을 새로 만들어서 핸들러가 config manager를 들고다니지 않아도 되도록 했습니다.
- TCP 핸들러가 Config을 통째로 받지 말고 TcpServerConfig만 받도록 했습니다.
- TlsInfo를 조금 수정해서 사용하는 곳의 코드가 깔끔해지게 했습니다.
- log 크레이트를 이용해서 데몬 모드에서는 좀 더 보기 좋은 로깅을 하도록 했습니다.
- 그 외에 리드미 수정 등등