### PR TITLE
Add contexts to errors, support IPv6, and refactor

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::fs;
 use std::io::*;
 use std::path::{Path, PathBuf};
@@ -37,7 +38,7 @@ impl Config {
 #[derive(Debug, Clone)]
 pub struct TcpServerConfig {
     pub enabled: bool,
-    pub port: u64,
+    pub port: u16,
 }
 
 // reimplementation of Ini::getboolcoerce, because of "on"/"off" string handling, which is valid
@@ -62,7 +63,8 @@ impl TcpServerConfig {
         let enabled = get_bool_coerce(ini, "tcp", "tcp_server")?.unwrap_or(true);
         let port = ini
             .getuint("tcp", "tcp_port")
-            .map_err(Error::msg)?
+            .map_err(Error::msg)
+            .and_then(|o| o.map(TryInto::try_into).transpose().map_err(Into::into))?
             .unwrap_or(46352);
         Ok(Self { enabled, port })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 
 mod config;
 mod opt;
@@ -11,8 +11,12 @@ fn main() -> Result<()> {
     // parse command-line arguments
     let opt = opt::Opt::from_args();
     let config_manager = config::ConfigManager::new();
-    config_manager.ensure_config_dir_exists()?;
-    config_manager.ensure_certificate_and_rsa_private_key_exists()?;
+    config_manager
+        .ensure_config_dir_exists()
+        .context("failed to ensure config dir exists")?;
+    config_manager
+        .ensure_certificate_and_rsa_private_key_exists()
+        .context("failed to ensure certificate and RSA private key exists")?;
     let config = config_manager.get_or_create_config()?;
 
     if !config.tcp.enabled && !config.bluetooth.enabled {
@@ -20,8 +24,10 @@ fn main() -> Result<()> {
     }
 
     // load tls config
-    let certs = tls::load_certs(&config_manager.certificate_path())?;
-    let privkey = tls::load_private_key(&config_manager.rsa_private_key_path())?;
+    let certs =
+        tls::load_certs(&config_manager.certificate_path()).context("failed to load certs")?;
+    let privkey = tls::load_private_key(&config_manager.rsa_private_key_path())
+        .context("failed to load RSA private key")?;
     if certs.is_empty() {
         bail!("there are no loaded certificate")
     } else if certs.len() > 1 {
@@ -35,20 +41,29 @@ fn main() -> Result<()> {
             Some(opt::Subcommand::Pair) => {
                 // pairing request
                 let authorized_certs_manager = config_manager.authorized_certs_manager();
-                let tls_config = tls_info.build()?;
-                tcp::pairing_tcp_handler(&config.tcp, &authorized_certs_manager, tls_config)?;
+                let tls_config = tls_info
+                    .build()
+                    .context("failed to build TLS configuration")?;
+                tcp::pairing_tcp_handler(&config.tcp, &authorized_certs_manager, tls_config)
+                    .context("failed to handle TCP pairing")?;
             }
             None => {
                 simple_logger::SimpleLogger::new()
                     .with_level(log::LevelFilter::Info)
-                    .init()?;
+                    .init()
+                    .context("failed to initialize logger")?;
 
                 // notification daemon mode
-                let authorized_certs = config_manager.authorized_certs_manager().load()?;
+                let authorized_certs = config_manager
+                    .authorized_certs_manager()
+                    .load()
+                    .context("failed to load authorized certs")?;
                 let tls_config = tls_info
                     .with_client_auth(utils::hashmap_into_values(authorized_certs))
-                    .build()?;
-                tcp::notification_tcp_handler(&config.tcp, tls_config)?;
+                    .build()
+                    .context("failed to build TLS configuration")?;
+                tcp::notification_tcp_handler(&config.tcp, tls_config)
+                    .context("failed to handle TCP notification daemon")?;
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,6 @@ mod tls;
 mod utils;
 
 fn main() -> Result<()> {
-    simple_logger::SimpleLogger::new()
-        .with_level(log::LevelFilter::Info)
-        .init()?;
-
     // parse command-line arguments
     let opt = opt::Opt::from_args();
     let config_manager = config::ConfigManager::new();
@@ -43,6 +39,10 @@ fn main() -> Result<()> {
                 tcp::pairing_tcp_handler(&config.tcp, &authorized_certs_manager, tls_config)?;
             }
             None => {
+                simple_logger::SimpleLogger::new()
+                    .with_level(log::LevelFilter::Info)
+                    .init()?;
+
                 // notification daemon mode
                 let authorized_certs = config_manager.authorized_certs_manager().load()?;
                 let tls_config = tls_info

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -25,6 +25,7 @@ pub fn pairing_tcp_handler(
 ) -> Result<()> {
     let port = config.port;
     let listener = new_tcp_listener(port)?;
+    println!("listening for pairing requests at port {}", port);
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
@@ -139,6 +140,7 @@ fn handle_pair_request(
 pub fn notification_tcp_handler(config: &TcpServerConfig, tls_info: TlsInfo) -> Result<()> {
     let port = config.port as u16;
     let listener = new_tcp_listener(port)?;
+    log::info!("listening for notifications at port {}", port);
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 use std::io::prelude::*;
-use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream};
 use std::time::Duration;
 
 use anyhow::{bail, Result};
@@ -10,14 +10,21 @@ use crate::config::{AuthorizedCertsManager, TcpServerConfig};
 use crate::protocol::{ConnType, NotificationFlag, PairingResponse};
 use crate::tls::TlsInfo;
 
+fn new_tcp_listener(port: u16) -> Result<TcpListener> {
+    let bind_addrs: &[_] = &[
+        SocketAddr::from((Ipv4Addr::UNSPECIFIED, port)),
+        SocketAddr::from((Ipv6Addr::UNSPECIFIED, port)),
+    ];
+    Ok(TcpListener::bind(bind_addrs)?)
+}
+
 pub fn pairing_tcp_handler(
     config: &TcpServerConfig,
     authorized_certs_manager: &AuthorizedCertsManager,
     tls_info: TlsInfo,
 ) -> Result<()> {
     let port = config.port;
-    let bind_addr = SocketAddr::from(([0, 0, 0, 0], port as u16));
-    let listener = TcpListener::bind(bind_addr)?;
+    let listener = new_tcp_listener(port)?;
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
@@ -130,9 +137,8 @@ fn handle_pair_request(
 }
 
 pub fn notification_tcp_handler(config: &TcpServerConfig, tls_info: TlsInfo) -> Result<()> {
-    let port = config.port;
-    let bind_addr = SocketAddr::from(([0, 0, 0, 0], port as u16));
-    let listener = TcpListener::bind(bind_addr)?;
+    let port = config.port as u16;
+    let listener = new_tcp_listener(port)?;
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -31,8 +31,8 @@ pub fn load_certs(filename: &Path) -> Result<Vec<rustls::Certificate>> {
     let certfile = fs::File::open(filename)?;
     let mut reader = BufReader::new(certfile);
     let certs = rustls_pemfile::certs(&mut reader)?
-        .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .into_iter()
+        .map(|v| rustls::Certificate(v))
         .collect();
     Ok(certs)
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -32,7 +32,7 @@ pub fn load_certs(filename: &Path) -> Result<Vec<rustls::Certificate>> {
     let mut reader = BufReader::new(certfile);
     let certs = rustls_pemfile::certs(&mut reader)?
         .into_iter()
-        .map(|v| rustls::Certificate(v))
+        .map(rustls::Certificate)
         .collect();
     Ok(certs)
 }


### PR DESCRIPTION
- 군데군데 눈에 띄는 부분을 리팩터링했습니다
- main에서만이라도 일단 context를 열심히 달았습니다. 에러가 나면 그냥 짧은 메시지만 띡 던져줘서 대체 뭐가 잘못된건지 알기 힘들더라구요..
  - 사실 러스트의 에러처리는 아직 구린 부분이 많습니다
- IPv6 지원을 추가했습니다.